### PR TITLE
Update symlink target for SingularityExecutor to actual singularity version

### DIFF
--- a/recipes/executor.rb
+++ b/recipes/executor.rb
@@ -33,7 +33,7 @@ when 'package'
   end
 
   link "#{node[:singularity][:home]}/bin/SingularityExecutor" do
-    to "#{node[:singularity][:home]}/bin/SingularityExecutor-0.4.2-shaded.jar"
+    to "#{node[:singularity][:home]}/bin/SingularityExecutor-#{node[:singularity][:version]}-shaded.jar"
   end
 when 'source'
   include_recipe 'singularity::source'


### PR DESCRIPTION
The maven resource builds a jar with the `node[:singularity][:version]` attribute which is used in the filename for the outputted jar