### PR TITLE
Add ability to supply args to SingularityExecutor

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -57,6 +57,9 @@ suites:
       singularity:
         executor:
           s3_bucket: example
+          extra_args:
+            - '-Xmx192M'
+            - '-test'
 
   - name: executor_source
     run_list:

--- a/attributes/executor.rb
+++ b/attributes/executor.rb
@@ -3,3 +3,6 @@ default['singularity']['executor']['task_dir'] = '/var/lib/singularity/executor-
 default['singularity']['executor']['s3_bucket'] = nil
 default['singularity']['executor']['s3_pattern'] = '/singularity/executor/tasks/'
 default['singularity']['executor']['log_dir'] = '/var/log/singularity-executor'
+default['singularity']['executor']['extra_args'] = [
+  '-Xmx128M'
+]

--- a/templates/default/singularity-executor.erb
+++ b/templates/default/singularity-executor.erb
@@ -14,5 +14,8 @@ if [ -n "$EXECUTOR_DEBUG" ]; then
 fi
 
 <%= node['java']['java_home'] %>/bin/java \
+  <% node['singularity']['executor']['extra_args'].each do |arg| -%>
+  <%= arg %> \
+  <%- end %>
   -Djava.library.path=/usr/local/lib \
   -jar <%= node['singularity']['home'] %>/bin/SingularityExecutor

--- a/test/integration/helpers/serverspec/executor.rb
+++ b/test/integration/helpers/serverspec/executor.rb
@@ -43,6 +43,8 @@ shared_examples_for 'an executor install' do
     describe '#content' do
       subject { super().content }
       it { is_expected.to include '/usr/local/singularity/bin/SingularityExecutor' }
+      it { is_expected.to include "-Xmx192M \\\n" }
+      it { is_expected.to include "-test \\\n" }
     end
   end
 end


### PR DESCRIPTION
This allows one to fine-tune additional arguments supplied to the SingularityExecutor.

h/t to @TNorden

@tpetr @ssalinas, any reason this wouldn’t work? Trying to control the memory usage of our Java tasks in Mesos.