### PR TITLE
Add Executor Log File

### DIFF
--- a/attributes/executor.rb
+++ b/attributes/executor.rb
@@ -6,3 +6,4 @@ default['singularity']['executor']['log_dir'] = '/var/log/singularity-executor'
 default['singularity']['executor']['extra_args'] = [
   '-Xmx128M'
 ]
+default['singularity']['executor']['log_file'] = 'service.log'

--- a/templates/default/singularity.executor.yaml.erb
+++ b/templates/default/singularity.executor.yaml.erb
@@ -3,3 +3,4 @@ globalTaskDefinitionDirectory: <%= node['singularity']['executor']['task_dir'] %
 s3UploaderBucket: <%= node['singularity']['executor']['s3_bucket'] %>
 s3UploaderKeyPattern: <%= node['singularity']['executor']['s3_pattern'] %>
 taskAppDirectory: .
+serviceLog: <%= node['singularity']['executor']['log_file'] %>

--- a/test/integration/helpers/serverspec/executor.rb
+++ b/test/integration/helpers/serverspec/executor.rb
@@ -21,6 +21,7 @@ shared_examples_for 'an executor install' do
     describe '#content' do
       subject { super().content }
       it { is_expected.to include 's3UploaderBucket: example' }
+      it { is_expected.to include 'serviceLog: service.log' }
     end
   end
 


### PR DESCRIPTION
- Adds executor log file
- Uses default in the java config, service.log
- Allows us to use log tailing for java apps in the singularity ui